### PR TITLE
Implement main and logging

### DIFF
--- a/src/logger.py
+++ b/src/logger.py
@@ -1,15 +1,3 @@
-# TODO - you'll need a logger, dont worry about structured logs at this point
-# (as we'll want a generic one that all the apps use) but come up with something
-# that'll support the basic patterns of:
-#
-# logger.debug("message", data={"some": "field"})
-# and
-# logger.error("message", data={"other": "field", error=[Python Exception]})
-#
-# As long as it will accept those signatures that's enough for now, we can nuance
-# the logger later that way without having to change any logging statements you
-# add to the wider app.
-
 import logging
 
 logger = logging.getLogger("logger")

--- a/src/logger.py
+++ b/src/logger.py
@@ -9,3 +9,7 @@
 # As long as it will accept those signatures that's enough for now, we can nuance
 # the logger later that way without having to change any logging statements you
 # add to the wider app.
+
+import logging
+
+logger = logging.getLogger("logger")

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,4 @@
 from typing import List
-from unittest.mock import Base
 import os
 
 from src.crawlers.base import BaseCrawler
@@ -15,20 +14,7 @@ def crawl(crawlers: List[BaseCrawler]):
         try:
             crawler.crawl()
         except Exception as err:
-            logger.error(f"Error occured while attempting to call crawler {crawler}")
-            
-            # TODO
-            # Something with this error, the key point
-            # is the crawler cannot fall over.
-            # Make this error LOUD as an exception from
-            # a crawler means ALL links its responisble
-            # for crawling are potentially not updated, but
-            # do not block or knock over the cache crawler
-            # itself (if needs to keep going and try and 
-            # next crawler).
-            # Ideally errors would be caught before this
-            # point but this is our safety.
-            ...
+            logger.exception(err)
             
 
 def main(crawler_list: List[BaseCrawler]):
@@ -49,8 +35,7 @@ def main(crawler_list: List[BaseCrawler]):
             )
         except Exception as err:
             logger.error(f"Error occured while attempting to instantiate and initiate crawler {crawler}")
-            raise
-            ...
+            raise err
 
     crawl(instanitated_crawler_list)
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,10 @@
 from typing import List
 from unittest.mock import Base
+import os
 
 from src.crawlers.base import BaseCrawler
 from crawlers import DatasetApiCrawler
+from logger import logger
 
 def crawl(crawlers: List[BaseCrawler]):
     """
@@ -13,6 +15,7 @@ def crawl(crawlers: List[BaseCrawler]):
         try:
             crawler.crawl()
         except Exception as err:
+            logger.error(f"Error occured while attempting to call crawler {crawler}")
             
             # TODO
             # Something with this error, the key point
@@ -30,9 +33,9 @@ def crawl(crawlers: List[BaseCrawler]):
 
 def main(crawler_list: List[BaseCrawler]):
 
-    # TODO - get the domain from an env var, eg:
-    # DOMAIN_ROOT="staging.idpd.uk"
-    DOMAIN_ROOT = "" # get it from an env var
+    DOMAIN_ROOT = os.environ.get("DOMAIN_ROOT")
+    if not DOMAIN_ROOT:
+        raise ValueError("DOMAIN_ROOT not found, please ensure environment variable is correct.")
 
     # Initiate the crawlers in a controlled way so
     # we can make sure none of them error during this
@@ -45,12 +48,8 @@ def main(crawler_list: List[BaseCrawler]):
                 crawler(DOMAIN_ROOT)
             )
         except Exception as err:
-           # NOTE - you CAN (and should) raise here, if it
-           # wont start it wont get deployed which is the correct
-           # behaviour for failed instantiation.
-           # Beyond this level you do NOT want to 
-           # be raising uncontroled errors as we dont
-           # want a dployed app falling over.
+            logger.error(f"Error occured while attempting to instantiate and initiate crawler {crawler}")
+            raise
             ...
 
     crawl(instanitated_crawler_list)


### PR DESCRIPTION
Created a logger and used it throughout main.py. Initially I began implementing a bigger custom logger class that was more akin to what we use in the idpd-api-poc repo, but I realised that for the purposes we need it for here a simple logger (i.e. just with getLogger) would be enough. I'm wondering if this maybe isn't future proof, which depends on what we want to do here when we work on it more, so please let me know what you think.

Currently it logs out any errors that occur in the crawl() function but does not raise them, and logs out/raises any errors that occur in the main() function.

Also added an exception if domain_root is none.